### PR TITLE
patched questions being registered twice

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -15,8 +15,6 @@ var question3;
 var possibleQuestions = [];
 var possibleAnswers = [];
 
-registerQuestions();
-
 function randomQuestion() {
     var indexQuestion = Math.floor(Math.random() * possibleQuestions.length);
     var indexCorrectAnswer = Math.floor(Math.random() * answerContainersAll.length);
@@ -75,6 +73,7 @@ function submitWrong() {
 
 
 function gameStart() {
+    console.log("Starting new game")
     //Shows all answer buttons
     for (var i = 0; i < answerContainersAll.length; i++) {
         answerContainersAll[i].style.visibility = "visible";


### PR DESCRIPTION
The questions list was being registered once on page load, and then again one the start button was pressed. Removed the registerQuestions at page load to prevent each unintended repeats in questions.